### PR TITLE
don't explode on unrecognized headers

### DIFF
--- a/src/main/scala/com/twitter/joauth/UnpackedRequest.scala
+++ b/src/main/scala/com/twitter/joauth/UnpackedRequest.scala
@@ -94,7 +94,7 @@ object OAuth1Request {
       }
       else if (oAuth1Params.version != null &&
           oAuth1Params.version != OAuthParams.ONE_DOT_OH &&
-          oAuth1Params.version != OAuthParams.ONE_DOT_OH_A) {
+          oAuth1Params.version.toLowerCase != OAuthParams.ONE_DOT_OH_A) {
         throw new MalformedRequest(UNSUPPORTED_VERSION+oAuth1Params.version)
       }
       // we don't check the validity of the OAuthParams object, because it must be

--- a/src/main/scala/com/twitter/joauth/Unpacker.scala
+++ b/src/main/scala/com/twitter/joauth/Unpacker.scala
@@ -158,6 +158,7 @@ class StandardUnpacker(
       queryParser(request.body, handlerSeq)
     }
 
+    // parse the header, if present
     parseHeader(request.authHeader, filteredOAuthKvHandler)
 
     // now we just return the accumulated parameters and OAuthParams
@@ -198,7 +199,7 @@ class StandardUnpacker(
           }
         }
       }
-      case None =>
+      case _ =>
     }
   }
 }

--- a/src/test/scala/com/twitter/joauth/UnpackerSpec.scala
+++ b/src/test/scala/com/twitter/joauth/UnpackerSpec.scala
@@ -52,6 +52,12 @@ class UnpackerSpec extends Specification with Mockito {
       request.scheme = "https"
       unpacker(request) must containTheToken("a")
     }
+    "unpack request with token in params HTTPS and junk Auth header" in {
+      val request = MockRequestFactory.oAuth2RequestInParams("a")
+      request.scheme = "https"
+      request.authHeader = Some("BLARG")
+      unpacker(request) must containTheToken("a")
+    }
     "unpack request with token in params HTTPS in POST" in {
       val request = MockRequestFactory.postRequest(MockRequestFactory.oAuth2RequestInParams("a"))
       request.scheme = "https"
@@ -96,6 +102,16 @@ class UnpackerSpec extends Specification with Mockito {
         val request = testCase.request(oAuthInParams, oAuthInHeader, paramsInPost)
         val (parsedRequest, oAuthParamsBuilder) = unpacker.parseRequest(request, Seq(kvHandler))
         unpacker.getOAuth1Request(parsedRequest, oAuthParamsBuilder.oAuth1Params) must be_==(testCase.oAuth1Request(paramsInPost))
+      }
+      // make sure get/post parsing still works with junky auth header
+      if (!oAuthInHeader) {
+        // Parse request
+        getTestName("parse oauth with junk auth header", testCase.testName, oAuthInParams, false, paramsInPost) in {
+          val request = testCase.request(oAuthInParams, oAuthInHeader, paramsInPost)
+          request.authHeader = Some("BLARG")
+          val (parsedRequest, oAuthParamsBuilder) = unpacker.parseRequest(request, Seq(kvHandler))
+          unpacker.getOAuth1Request(parsedRequest, oAuthParamsBuilder.oAuth1Params) must be_==(testCase.oAuth1Request(paramsInPost))
+        }
       }
       // Unpack Request
       val request = testCase.request(oAuthInParams, oAuthInHeader, paramsInPost)

--- a/src/test/scala/com/twitter/joauth/testhelpers/OAuth1TestCase.scala
+++ b/src/test/scala/com/twitter/joauth/testhelpers/OAuth1TestCase.scala
@@ -74,7 +74,7 @@ case class OAuth1TestCase(
     else UrlDecoder(signature)
   }
 
-  def request(oAuthInParam: Boolean, oAuthInHeader: Boolean, paramsInPost: Boolean): Request = {
+  def request(oAuthInParam: Boolean, oAuthInHeader: Boolean, paramsInPost: Boolean): MockRequest = {
     val signature = if (paramsInPost) signaturePost else signatureGet
     var request = new MockRequest
     request.method = "GET"


### PR DESCRIPTION
- don't blow up when the header regex fails to match
- allow 1.0A version string
