### PR TITLE
Update to Scala 2.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: scala
 scala:
-  - 2.9.2
+  - 2.10.2
 script: mvn test

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.9.2</version>
+      <version>${scala.version}</version>
     </dependency>
     <!-- project dependencies -->
     <dependency>
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>org.scala-tools.testing</groupId>
-      <artifactId>specs_2.9.1</artifactId>
+      <artifactId>specs_2.10</artifactId>
       <version>1.6.9</version>
       <scope>test</scope>
     </dependency>
@@ -42,6 +42,11 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
   </dependencies>
@@ -74,7 +79,7 @@
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <scala.version>2.9.2</scala.version>
+    <scala.version>2.10.2</scala.version>
     <slf4j.version>1.7.5</slf4j.version>
   </properties>
 

--- a/src/test/scala/com/twitter/joauth/keyvalue/KeyValueHandlerSpec.scala
+++ b/src/test/scala/com/twitter/joauth/keyvalue/KeyValueHandlerSpec.scala
@@ -46,7 +46,7 @@ class KeyValueHandlerSpec extends SpecificationWithJUnit with Mockito {
       handler("foo" , "   baz  ")
       there were 3.times(underlying).apply("foo", "baz")
       there was one(underlying).apply("foo", "   baz  ")
-      there were 4.times(underlying).apply(any, any)
+      there were 4.times(underlying).apply(any[String], any[String])
     }
 
   }


### PR DESCRIPTION
The current version is compiled against scala 2.9.2 and cannot be used in a 2.10 release because of some breaking changes to `RichInt`.

Required a spec change and explicitly adding org.slf4j:slf4j-simple, because one
logging provider shipped with the package would be dynamically loaded in a test
and cause the suite to fail.
