### PR TITLE
Making the token length limit configurable

### DIFF
--- a/src/main/java/com/twitter/joauth/UnpackedRequest.java
+++ b/src/main/java/com/twitter/joauth/UnpackedRequest.java
@@ -341,14 +341,15 @@ public interface UnpackedRequest {
     private static final String UNSUPPORTED_VERSION = "unsupported oauth version: ";
     private static final String MALFORMED_TOKEN = "malformed oauth token: ";
 
-    // For security reasons MaxTokenLength was increased from 50 to 100 instead of being completely removed
-    private static final int MaxTokenLength = 100;
-
     private void throwMalformedException(String name) throws MalformedRequest {
       throw new MalformedRequest(NO_VALUE_FOR+name);
     }
 
-    public void verify(Request.ParsedRequest parsedRequest, OAuthParams.OAuth1Params oAuth1Params) throws MalformedRequest {
+    public void verify(
+        Request.ParsedRequest parsedRequest,
+        OAuthParams.OAuth1Params oAuth1Params,
+        int maxtokenLength
+        ) throws MalformedRequest {
       if (parsedRequest.scheme() == null) throwMalformedException(SCHEME);
       else if (parsedRequest.host() == null) throwMalformedException(HOST);
       else if (parsedRequest.port() < 0) throwMalformedException(PORT);
@@ -365,7 +366,7 @@ public interface UnpackedRequest {
         throw new MalformedRequest(UNSUPPORTED_VERSION + oAuth1Params.version());
       }
       else if (oAuth1Params.token() != null &&
-          (oAuth1Params.token().indexOf(' ') > 0 || oAuth1Params.token().length() > MaxTokenLength)) {
+          (oAuth1Params.token().indexOf(' ') > 0 || oAuth1Params.token().length() > maxtokenLength)) {
         throw new MalformedRequest(MALFORMED_TOKEN + oAuth1Params.token());
       }
       // we don't check the validity of the OAuthParams object, because it must be
@@ -376,10 +377,11 @@ public interface UnpackedRequest {
     public OAuth1Request buildOAuth1Request(
       Request.ParsedRequest parsedRequest,
       OAuthParams.OAuth1Params oAuth1Params,
-      Normalizer normalize
+      Normalizer normalize,
+      int maxTokenLength
     ) throws MalformedRequest, UnsupportedEncodingException {
 
-      verify(parsedRequest, oAuth1Params);
+      verify(parsedRequest, oAuth1Params, maxTokenLength);
 
       return new OAuth1Request(
         UrlCodec.decode(oAuth1Params.token()), // should never be called when token is None
@@ -398,10 +400,11 @@ public interface UnpackedRequest {
     public OAuth1TwoLeggedRequest buildOAuth1TwoLeggedRequest(
       Request.ParsedRequest parsedRequest,
       OAuthParams.OAuth1Params oAuth1Params,
-      Normalizer normalize
+      Normalizer normalize,
+      int maxTokenLength
     ) throws MalformedRequest, UnsupportedEncodingException {
 
-      verify(parsedRequest, oAuth1Params);
+      verify(parsedRequest, oAuth1Params, maxTokenLength);
 
       return new OAuth1TwoLeggedRequest(
         UrlCodec.decode(oAuth1Params.consumerKey()),

--- a/src/main/java/com/twitter/joauth/UnpackedRequest.java
+++ b/src/main/java/com/twitter/joauth/UnpackedRequest.java
@@ -341,8 +341,8 @@ public interface UnpackedRequest {
     private static final String UNSUPPORTED_VERSION = "unsupported oauth version: ";
     private static final String MALFORMED_TOKEN = "malformed oauth token: ";
 
-    //TODO: remove MaxTokenLength, this limit is specific to twitter
-    private static final int MaxTokenLength = 50;   // This is limited by DB schema
+    // For security reasons MaxTokenLength was increased from 50 to 100 instead of being completely removed
+    private static final int MaxTokenLength = 100;
 
     private void throwMalformedException(String name) throws MalformedRequest {
       throw new MalformedRequest(NO_VALUE_FOR+name);

--- a/src/main/java/com/twitter/joauth/UnpackedRequest.java
+++ b/src/main/java/com/twitter/joauth/UnpackedRequest.java
@@ -348,7 +348,7 @@ public interface UnpackedRequest {
     public void verify(
         Request.ParsedRequest parsedRequest,
         OAuthParams.OAuth1Params oAuth1Params,
-        int maxtokenLength
+        int maxTokenLength
         ) throws MalformedRequest {
       if (parsedRequest.scheme() == null) throwMalformedException(SCHEME);
       else if (parsedRequest.host() == null) throwMalformedException(HOST);
@@ -366,7 +366,7 @@ public interface UnpackedRequest {
         throw new MalformedRequest(UNSUPPORTED_VERSION + oAuth1Params.version());
       }
       else if (oAuth1Params.token() != null &&
-          (oAuth1Params.token().indexOf(' ') > 0 || oAuth1Params.token().length() > maxtokenLength)) {
+          (oAuth1Params.token().indexOf(' ') > 0 || oAuth1Params.token().length() > maxTokenLength)) {
         throw new MalformedRequest(MALFORMED_TOKEN + oAuth1Params.token());
       }
       // we don't check the validity of the OAuthParams object, because it must be

--- a/src/main/java/com/twitter/joauth/Unpacker.java
+++ b/src/main/java/com/twitter/joauth/Unpacker.java
@@ -52,6 +52,10 @@ public interface Unpacker {
     public static final String WWW_FORM_URLENCODED = "application/x-www-form-urlencoded";
     public static final String HTTPS = "HTTPS";
 
+    // Keeping the old maxTokenLength value as default one
+    // Previously it was defined in OAuth1RequestHelper
+    public static final int DEFAULT_MAX_TOKEN_LENGTH = 50;
+
     private static final Logger log = Logger.getLogger("CustomizableUnpacker");
 
     private final OAuthParams.OAuthParamsHelper helper;
@@ -62,6 +66,7 @@ public interface Unpacker {
     private final KeyValueCallback bodyParamTransformer;
     private final KeyValueCallback headerTransformer;
     private final OAuth2Checker shouldAllowOAuth2;
+    private final int maxTokenLength;
 
     public CustomizableUnpacker(
       OAuthParams.OAuthParamsHelper helper,
@@ -71,7 +76,8 @@ public interface Unpacker {
       KeyValueCallback queryParamTransformer,
       KeyValueCallback bodyParamTransformer,
       KeyValueCallback headerTransformer,
-      OAuth2Checker shouldAllowOAuth2
+      OAuth2Checker shouldAllowOAuth2,
+      int maxTokenLength
     ) {
       this.helper = helper;
       this.normalizer = normalizer;
@@ -81,6 +87,29 @@ public interface Unpacker {
       this.bodyParamTransformer = bodyParamTransformer;
       this.headerTransformer = headerTransformer;
       this.shouldAllowOAuth2 = shouldAllowOAuth2;
+      this.maxTokenLength = maxTokenLength;
+    }
+
+    public CustomizableUnpacker(
+        OAuthParams.OAuthParamsHelper helper,
+        Normalizer normalizer,
+        KeyValueParser queryParser,
+        KeyValueParser headerParser,
+        KeyValueCallback queryParamTransformer,
+        KeyValueCallback bodyParamTransformer,
+        KeyValueCallback headerTransformer,
+        OAuth2Checker shouldAllowOAuth2
+    ) {
+      this(
+          helper,
+          normalizer,
+          queryParser,
+          headerParser,
+          queryParamTransformer,
+          bodyParamTransformer,
+          headerTransformer,
+          shouldAllowOAuth2,
+          DEFAULT_MAX_TOKEN_LENGTH);
     }
 
     private KeyValueHandler createKeyValueHandler(
@@ -244,7 +273,7 @@ public interface Unpacker {
         oAuth1Params.consumerKey(), oAuth1Params.signature(), oAuth1Params.signatureMethod()));
     }
 
-    return UnpackedRequest.O_AUTH_1_REQUEST_HELPER.buildOAuth1Request(parsedRequest, oAuth1Params, normalizer);
+    return UnpackedRequest.O_AUTH_1_REQUEST_HELPER.buildOAuth1Request(parsedRequest, oAuth1Params, normalizer, maxTokenLength);
   }
 
   public UnpackedRequest.OAuth1TwoLeggedRequest getOAuth1TwoLeggedRequest(
@@ -259,7 +288,7 @@ public interface Unpacker {
         oAuth1Params.signature(), oAuth1Params.signatureMethod()));
     }
 
-    return UnpackedRequest.O_AUTH_1_REQUEST_HELPER.buildOAuth1TwoLeggedRequest(parsedRequest, oAuth1Params, normalizer);
+    return UnpackedRequest.O_AUTH_1_REQUEST_HELPER.buildOAuth1TwoLeggedRequest(parsedRequest, oAuth1Params, normalizer, maxTokenLength);
   }
 
   public UnpackedRequest.OAuth2Request getOAuth2Request(

--- a/src/test/scala/com/twitter/joauth/OAuth1RequestSpec.scala
+++ b/src/test/scala/com/twitter/joauth/OAuth1RequestSpec.scala
@@ -46,12 +46,12 @@ class OAuth1RequestSpec extends SpecificationWithJUnit {
     }
     "not throw on supported HMAC-SHA1 signature method" in {
       builder.queryHandler.handle("oauth_signature_method", "HMAC-SHA1")
-      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params) 
+      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params, DEFAULT_MAX_TOKEN_LENGTH)
       1 must be_==(1)
     }
     "not throw on supported HMAC-SHA256 signature method" in {
       builder.queryHandler.handle("oauth_signature_method", "HMAC-SHA256")
-      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params) 
+      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params, DEFAULT_MAX_TOKEN_LENGTH)
       1 must be_==(1)
     }
     "throw on unsupported oauth version" in {

--- a/src/test/scala/com/twitter/joauth/OAuth1RequestSpec.scala
+++ b/src/test/scala/com/twitter/joauth/OAuth1RequestSpec.scala
@@ -13,6 +13,7 @@
 package com.twitter.joauth
 
 import com.twitter.joauth.keyvalue.KeyValueHandler.NullKeyValueHandler
+import com.twitter.joauth.Unpacker.CustomizableUnpacker.DEFAULT_MAX_TOKEN_LENGTH
 import org.specs.SpecificationWithJUnit
 
 class OAuth1RequestSpec extends SpecificationWithJUnit {
@@ -22,26 +23,26 @@ class OAuth1RequestSpec extends SpecificationWithJUnit {
       new Request.ParsedRequest(scheme, host, port, verb, path, new java.util.ArrayList[Request.Pair])
 
     "throw on null scheme" in {
-      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr(null, "2", 3, "4", "5"), builder.oAuth1Params) must throwA(new MalformedRequest("no value for scheme"))
+      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr(null, "2", 3, "4", "5"), builder.oAuth1Params, DEFAULT_MAX_TOKEN_LENGTH) must throwA(new MalformedRequest("no value for scheme"))
     }
     "throw on null host" in {
-      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", null, 3, "4", "5"), builder.oAuth1Params) must throwA(new MalformedRequest("no value for host"))
+      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", null, 3, "4", "5"), builder.oAuth1Params, DEFAULT_MAX_TOKEN_LENGTH) must throwA(new MalformedRequest("no value for host"))
     }
     "throw on null port" in {
-      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", -1, "4", "5"), builder.oAuth1Params) must throwA(new MalformedRequest("no value for port"))
+      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", -1, "4", "5"), builder.oAuth1Params, DEFAULT_MAX_TOKEN_LENGTH) must throwA(new MalformedRequest("no value for port"))
     }
     "throw on null verb" in {
-      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, null, "5"), builder.oAuth1Params) must throwA(new MalformedRequest("no value for verb"))
+      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, null, "5"), builder.oAuth1Params, DEFAULT_MAX_TOKEN_LENGTH) must throwA(new MalformedRequest("no value for verb"))
     }
     "throw on null path" in {
-      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", null), builder.oAuth1Params) must throwA(new MalformedRequest("no value for path"))
+      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", null), builder.oAuth1Params, DEFAULT_MAX_TOKEN_LENGTH) must throwA(new MalformedRequest("no value for path"))
     }
     "throw on null signature method" in {
-      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params) must throwA(new MalformedRequest("unsupported signature method: null"))
+      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params, DEFAULT_MAX_TOKEN_LENGTH) must throwA(new MalformedRequest("unsupported signature method: null"))
     }
     "throw on unsupported signature method" in {
       builder.queryHandler.handle("oauth_signature_method", "foo")
-      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params) must throwA(new MalformedRequest("unsupported signature method: foo"))
+      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params, DEFAULT_MAX_TOKEN_LENGTH) must throwA(new MalformedRequest("unsupported signature method: foo"))
     }
     "not throw on supported HMAC-SHA1 signature method" in {
       builder.queryHandler.handle("oauth_signature_method", "HMAC-SHA1")
@@ -56,24 +57,24 @@ class OAuth1RequestSpec extends SpecificationWithJUnit {
     "throw on unsupported oauth version" in {
       builder.queryHandler.handle("oauth_signature_method", "HMAC-SHA1")
       builder.queryHandler.handle("oauth_version", "1.1")
-      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params) must throwA(new MalformedRequest("unsupported oauth version: 1.1"))
+      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params, DEFAULT_MAX_TOKEN_LENGTH) must throwA(new MalformedRequest("unsupported oauth version: 1.1"))
     }
     "not throw for null oauth version" in {
       builder.queryHandler.handle("oauth_signature_method", "HMAC-SHA1")
-      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params)
+      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params, DEFAULT_MAX_TOKEN_LENGTH)
       1 must be_==(1)
     }
     "not throw for 1.0a oauth version" in {
       builder.queryHandler.handle("oauth_signature_method", "HMAC-SHA1")
       builder.queryHandler.handle("oauth_version", "1.0a")
-      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params)
+      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params, DEFAULT_MAX_TOKEN_LENGTH)
       1 must be_==(1)
     }
     "throw on malformed token" in {
       builder.queryHandler.handle("oauth_signature_method", "HMAC-SHA1")
       builder.queryHandler.handle("oauth_version", "1.0")
       builder.queryHandler.handle("oauth_token", "this ain't a token")
-      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params) must throwA(new MalformedRequest("malformed oauth token: this ain't a token"))
+      UnpackedRequest.O_AUTH_1_REQUEST_HELPER.verify(pr("1", "2", 3, "4", "5"), builder.oAuth1Params, DEFAULT_MAX_TOKEN_LENGTH) must throwA(new MalformedRequest("malformed oauth token: this ain't a token"))
     }
     "trim extra spaces on token" in {
       builder.queryHandler.handle("oauth_token", "  some_token  ")


### PR DESCRIPTION
Give user the ability to define its own maxTokenLength in CustomizableUnpacker. maxTokenLength is optional parameter, by default old value 50 is used. 