### PR TITLE
Use https instead of http in urls

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The tests are completely self contained, and can be run using Maven:
 
 ## Reporting problems
 
-The Github issue tracker is [here](http://github.com/9len/joauth/issues).
+The Github issue tracker is [here](https://github.com/9len/joauth/issues).
 
 ## Contributors
 
@@ -175,5 +175,5 @@ The Github issue tracker is [here](http://github.com/9len/joauth/issues).
 
 Copyright 2010-2013 Twitter, Inc.
 
-Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+Licensed under the Apache License, Version 2.0: https://www.apache.org/licenses/LICENSE-2.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>JOAuth</name>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.twitter</groupId>
   <artifactId>joauth</artifactId>
   <packaging>jar</packaging>
   <version>6.0.3</version>
-  <url>http://github.com/twitter/joauth</url>
+  <url>https://github.com/twitter/joauth</url>
   <description>A Java library for authenticating HTTP requests using OAuth</description>
   <dependencies>
     <!-- project dependencies -->
@@ -52,7 +52,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
   <developers>

--- a/project/plugins/Plugins.scala
+++ b/project/plugins/Plugins.scala
@@ -8,11 +8,11 @@ class Plugins(info: ProjectInfo) extends PluginDefinition(info) {
   def isInternal = isSBTOpenTwitter || isSBTTwitter
 
   override def repositories = if (isSBTOpenTwitter) {
-    Set("twitter.artifactory" at "http://artifactory.local.twitter.com/open-source/")
+    Set("twitter.artifactory" at "https://artifactory.local.twitter.com/open-source/")
   } else if (isSBTTwitter) {
-    Set("twitter.artifactory" at "http://artifactory.local.twitter.com/repo/")
+    Set("twitter.artifactory" at "https://artifactory.local.twitter.com/repo/")
   } else {
-    super.repositories ++ Seq("twitter.com" at "http://maven.twttr.com/")
+    super.repositories ++ Seq("twitter.com" at "https://maven.twttr.com/")
   }
 
   override def ivyRepositories =

--- a/src/main/java/com/twitter/joauth/Base64Util.java
+++ b/src/main/java/com/twitter/joauth/Base64Util.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,7 +39,7 @@ class Base64Util {
    * URL_SAFE and STANDARD base64. (The encoder, on the other hand, needs to know ahead of time what to emit).
    *
    * Thanks to "commons" project in ws.apache.org for this code.
-   * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
+   * https://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
    */
   private static final byte[] DECODE_TABLE = new byte[]{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,

--- a/src/main/java/com/twitter/joauth/NonceValidator.java
+++ b/src/main/java/com/twitter/joauth/NonceValidator.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/main/java/com/twitter/joauth/Normalizer.java
+++ b/src/main/java/com/twitter/joauth/Normalizer.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/main/java/com/twitter/joauth/OAuthParams.java
+++ b/src/main/java/com/twitter/joauth/OAuthParams.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/main/java/com/twitter/joauth/Request.java
+++ b/src/main/java/com/twitter/joauth/Request.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/main/java/com/twitter/joauth/Signer.java
+++ b/src/main/java/com/twitter/joauth/Signer.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/main/java/com/twitter/joauth/UnpackedRequest.java
+++ b/src/main/java/com/twitter/joauth/UnpackedRequest.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/main/java/com/twitter/joauth/Unpacker.java
+++ b/src/main/java/com/twitter/joauth/Unpacker.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/main/java/com/twitter/joauth/UnpackerException.java
+++ b/src/main/java/com/twitter/joauth/UnpackerException.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/main/java/com/twitter/joauth/UrlCodec.java
+++ b/src/main/java/com/twitter/joauth/UrlCodec.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/main/java/com/twitter/joauth/Verifier.java
+++ b/src/main/java/com/twitter/joauth/Verifier.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/main/java/com/twitter/joauth/VerifierResult.java
+++ b/src/main/java/com/twitter/joauth/VerifierResult.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 // 
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 // 
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/main/java/com/twitter/joauth/keyvalue/KeyValueHandler.java
+++ b/src/main/java/com/twitter/joauth/keyvalue/KeyValueHandler.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/main/java/com/twitter/joauth/keyvalue/KeyValueParser.java
+++ b/src/main/java/com/twitter/joauth/keyvalue/KeyValueParser.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/main/java/com/twitter/joauth/keyvalue/Transformer.java
+++ b/src/main/java/com/twitter/joauth/keyvalue/Transformer.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/test/java/com/twitter/joauth/keyvalue/KeyValueHandlerTest.java
+++ b/src/test/java/com/twitter/joauth/keyvalue/KeyValueHandlerTest.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/test/java/com/twitter/joauth/keyvalue/KeyValueParserTest.java
+++ b/src/test/java/com/twitter/joauth/keyvalue/KeyValueParserTest.java
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/test/scala/com/twitter/joauth/NormalizerSpec.scala
+++ b/src/test/scala/com/twitter/joauth/NormalizerSpec.scala
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/test/scala/com/twitter/joauth/OAuth1ParamsSpec.scala
+++ b/src/test/scala/com/twitter/joauth/OAuth1ParamsSpec.scala
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/test/scala/com/twitter/joauth/OAuth1RequestSpec.scala
+++ b/src/test/scala/com/twitter/joauth/OAuth1RequestSpec.scala
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/test/scala/com/twitter/joauth/SignerSpec.scala
+++ b/src/test/scala/com/twitter/joauth/SignerSpec.scala
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/test/scala/com/twitter/joauth/UnpackerSpec.scala
+++ b/src/test/scala/com/twitter/joauth/UnpackerSpec.scala
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/test/scala/com/twitter/joauth/VerifierSpec.scala
+++ b/src/test/scala/com/twitter/joauth/VerifierSpec.scala
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/test/scala/com/twitter/joauth/testhelpers/MockRequest.scala
+++ b/src/test/scala/com/twitter/joauth/testhelpers/MockRequest.scala
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/test/scala/com/twitter/joauth/testhelpers/MockRequestFactory.scala
+++ b/src/test/scala/com/twitter/joauth/testhelpers/MockRequestFactory.scala
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/test/scala/com/twitter/joauth/testhelpers/OAuth1TestCase.scala
+++ b/src/test/scala/com/twitter/joauth/testhelpers/OAuth1TestCase.scala
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/src/test/scala/com/twitter/joauth/testhelpers/ParamHelper.scala
+++ b/src/test/scala/com/twitter/joauth/testhelpers/ParamHelper.scala
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 // file except in compliance with the License. You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.